### PR TITLE
Restrict release auto publish only on main branch and update test

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,8 +25,10 @@ jobs:
       - name: Verify styling failure msg
         if: steps.style_verify.outcome == 'failure'
         run: echo "Please run 'npm run format' before commiting the code!"
-      - name: Run build
+      - name: Run build test
         run: npm run build
+      - name: Run junit
+        run: npm run junit
       - name: Upload results to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release-automation-app:
+    if: github.repository == 'opensearch-project/automation-app'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -2,6 +2,8 @@ name: Release Automation App
 
 on:
   push:
+    branches:
+      - main
 
 permissions:
   contents: write

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "An Automation App that handles all your GitHub Repository Activities",
   "author": "Peter Zhu",
   "homepage": "https://github.com/opensearch-project/automation-app",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "format": "prettier --write src/**/*.ts test/**/*.ts configs/**/*.yml",
     "format-dryrun": "prettier --check src/**/*.ts test/**/*.ts configs/**/*.yml",
     "lint": "eslint --fix \"src/**/*.ts\" --ignore-pattern \"**/*.d.ts\"",
-    "test": "jest --coverage --reporters=jest-junit"
+    "test": "jest --coverage",
+    "junit": "jest --reporters=jest-junit"
   },
   "dependencies": {
     "@aws-sdk/client-opensearch": "^3.658.1",


### PR DESCRIPTION
### Description
Restrict release auto publish only on main branch and update test

Update test commands:
--coverage will not only test but also generate codecov reports
--reports=jest-junit will not test but will scan through test folder and find all the test cases and save in junit.xml so it can record how many times it failed.

### Issues Resolved
Closes https://github.com/opensearch-project/automation-app/issues/13

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
