### PR TITLE
Added indexing user activity events operation

### DIFF
--- a/configs/operations/github-activity-events-monitor.yml
+++ b/configs/operations/github-activity-events-monitor.yml
@@ -9,16 +9,17 @@ events:
   - issues.transferred
   - issues.assigned
   - issue_comment.created
-  - push
   - pull_request.closed
   - pull_request.opened
   - pull_request.labeled
   - pull_request.unlabeled
   - pull_request.assigned
   - pull_request_review.submitted
+  - pull_request_review_comment.created
   - gollum
-  - release.released
-  - project.edited
+#  - push
+#  - release.released
+#  - project.edited
 
 tasks:
   - name: Activity Events Monitor Operation

--- a/configs/operations/github-activity-events-monitor.yml
+++ b/configs/operations/github-activity-events-monitor.yml
@@ -1,0 +1,25 @@
+---
+name: Activity Events Monitor
+
+events:
+  - issues.opened
+  - issues.closed
+  - issues.labeled
+  - issues.unlabeled
+  - issues.transferred
+  - issues.assigned
+  - issue_comment.created
+  - push
+  - pull_request.closed
+  - pull_request.opened
+  - pull_request.labeled
+  - pull_request.unlabeled
+  - pull_request.assigned
+  - pull_request_review.submitted
+  - gollum
+  - release.released
+  - project.edited
+
+tasks:
+  - name: Activity Events Monitor Operation
+    call: github-activity-events-monitor@default

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "An Automation App that handles all your GitHub Repository Activities",
   "author": "Peter Zhu",
   "homepage": "https://github.com/opensearch-project/automation-app",

--- a/src/call/github-activity-events-monitor.ts
+++ b/src/call/github-activity-events-monitor.ts
@@ -21,7 +21,7 @@ export default async function githubActivityEventsMonitor(app: Probot, context: 
   const repoName = context.payload.repository?.name;
   const orgName = context.payload.organization?.login || context.payload.repository?.owner?.login;
 
-  const logData = {
+  const event = {
     id: context.id,
     organization: orgName,
     repository: repoName,
@@ -38,10 +38,10 @@ export default async function githubActivityEventsMonitor(app: Probot, context: 
   try {
     await client.index({
       index: `github-activity-events-${month}-${year}`,
-      body: logData,
+      body: event,
     });
-    app.log.info('Log data indexed successfully.');
+    app.log.info('Event indexed successfully.');
   } catch (error) {
-    app.log.error(`Error indexing log data: ${error}`);
+    app.log.error(`Error indexing event: ${error}`);
   }
 }

--- a/src/call/github-activity-events-monitor.ts
+++ b/src/call/github-activity-events-monitor.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+// Name         : githubActivityEventsMonitor
+// Description  : Indexes events pertaining to user activity to OpenSearch
+
+import { Probot } from 'probot';
+import { Resource } from '../service/resource/resource';
+import { validateResourceConfig } from '../utility/verification/verify-resource';
+import { OpensearchClient } from '../utility/opensearch/opensearch-client';
+
+export default async function githubActivityEventsMonitor(app: Probot, context: any, resource: Resource): Promise<void> {
+  if (!(await validateResourceConfig(app, context, resource))) return;
+
+  const repoName = context.payload.repository?.name;
+  const orgName = context.payload.organization?.login || context.payload.repository?.owner?.login;
+
+  const logData = {
+    id: context.id,
+    organization: orgName,
+    repository: repoName,
+    type: context.name,
+    action: context.payload.action,
+    sender: context.payload.sender?.login,
+    created_at: new Date().toISOString(),
+  };
+
+  const client = await new OpensearchClient().getClient();
+
+  const [month, year] = [new Date().getMonth() + 1, new Date().getFullYear()].map((num) => String(num).padStart(2, '0'));
+
+  try {
+    await client.index({
+      index: `github-activity-events-${month}-${year}`,
+      body: logData,
+    });
+    app.log.info('Log data indexed successfully.');
+  } catch (error) {
+    app.log.error(`Error indexing log data: ${error}`);
+  }
+}

--- a/test/call/github-activity-events-monitor.test.ts
+++ b/test/call/github-activity-events-monitor.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Logger, Probot } from 'probot';
+import { OpensearchClient } from '../../src/utility/opensearch/opensearch-client';
+import githubActivityEventsMonitor from '../../src/call/github-activity-events-monitor';
+
+jest.mock('../../src/utility/opensearch/opensearch-client');
+
+describe('githubActivityEventsMonitor', () => {
+  let app: Probot;
+  let context: any;
+  let resource: any;
+
+  beforeEach(() => {
+    app = new Probot({ appId: 1, secret: 'test', privateKey: 'test' });
+    app.log = {
+      info: jest.fn(),
+      error: jest.fn(),
+    } as unknown as Logger;
+    context = {
+      name: 'eventType',
+      id: 'id',
+      payload: {
+        repository: {
+          name: 'repo',
+          owner: { login: 'org' },
+        },
+        action: 'action',
+        sender: {
+          login: 'sender',
+        },
+      },
+    };
+    resource = {
+      organizations: new Map([
+        [
+          'org',
+          {
+            repositories: new Map([['repo', 'repo object']]),
+          },
+        ],
+      ]),
+    };
+  });
+
+  it('should index events', async () => {
+    const mockClient = {
+      index: jest.fn().mockResolvedValue({}),
+    };
+    (OpensearchClient as jest.Mock).mockImplementation(() => {
+      return { getClient: jest.fn().mockResolvedValue(mockClient) };
+    });
+    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-10-04T21:00:06.875Z');
+    await githubActivityEventsMonitor(app, context, resource);
+    expect(mockClient.index).toHaveBeenCalledWith({
+      index: expect.stringMatching(/^github-activity-events-\d{2}-\d{4}$/),
+      body: expect.objectContaining({
+        id: 'id',
+        organization: 'org',
+        repository: 'repo',
+        type: 'eventType',
+        action: 'action',
+        sender: 'sender',
+        created_at: '2024-10-04T21:00:06.875Z',
+      }),
+    });
+    expect(app.log.info).toHaveBeenCalledWith('Event indexed successfully.');
+  });
+
+  it('should log an error if indexing fails', async () => {
+    const mockClient = {
+      index: jest.fn().mockRejectedValue(new Error('Indexing failed')),
+    };
+    (OpensearchClient as jest.Mock).mockImplementation(() => {
+      return { getClient: jest.fn().mockResolvedValue(mockClient) };
+    });
+    await githubActivityEventsMonitor(app, context, resource);
+    expect(app.log.error).toHaveBeenCalledWith('Error indexing event: Error: Indexing failed');
+  });
+});


### PR DESCRIPTION
### Description
Coming from https://github.com/opensearch-project/opensearch-metrics/issues/76

Added operation to index events pertaining to user activity into an OpenSearch cluster for further processing to monitor Maintainer activity.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/57

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
