### PR TITLE
Changed bucket name to env variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-automation-app",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.664.0",
         "@aws-sdk/client-opensearch": "^3.658.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "An Automation App that handles all your GitHub Repository Activities",
   "author": "Peter Zhu",
   "homepage": "https://github.com/opensearch-project/automation-app",

--- a/src/call/github-events-to-s3.ts
+++ b/src/call/github-events-to-s3.ts
@@ -26,7 +26,7 @@ export default async function githubEventsToS3(app: Probot, context: any, resour
   try {
     const s3Client = new S3Client({ region: String(process.env.REGION) });
     const putObjectCommand = new PutObjectCommand({
-      Bucket: 'opensearch-project-github-events',
+      Bucket: String(process.env.OPENSEARCH_EVENTS_BUCKET),
       Body: JSON.stringify(context),
       Key: `${context.name}.${context.payload.action}/${year}-${month}-${day}/${repoName}-${context.id}`,
     });


### PR DESCRIPTION
### Description
Changed bucket name to env variable to allow the user to chose which s3 bucket to upload events to.

### Issues Resolved
https://github.com/opensearch-project/opensearch-metrics/pull/85

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
