### PR TITLE
Added timestamp to raw event json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-automation-app",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.664.0",
         "@aws-sdk/client-opensearch": "^3.658.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "An Automation App that handles all your GitHub Repository Activities",
   "author": "Peter Zhu",
   "homepage": "https://github.com/opensearch-project/automation-app",

--- a/src/call/github-events-to-s3.ts
+++ b/src/call/github-events-to-s3.ts
@@ -21,6 +21,8 @@ export default async function githubEventsToS3(app: Probot, context: any, resour
   const repoName = context.payload.repository?.name;
   const eventName = context.payload.action === undefined ? context.name : `${context.name}.${context.payload.action}`;
 
+  context.uploaded_at = new Date().toISOString();
+
   const now = new Date();
   const [day, month, year] = [now.getDate(), now.getMonth() + 1, now.getFullYear()].map((num) => String(num).padStart(2, '0'));
 

--- a/test/call/github-events-to-s3.test.ts
+++ b/test/call/github-events-to-s3.test.ts
@@ -90,11 +90,13 @@ describe('githubEventsToS3', () => {
     jest.spyOn(Date.prototype, 'getDate').mockReturnValue(4);
     jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(8);
     jest.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2024);
+    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-10-04T21:00:06.875Z');
 
     await githubEventsToS3(app, context, resource);
 
     expect(PutObjectCommand).toHaveBeenCalledWith(
       expect.objectContaining({
+        Body: expect.stringMatching('"uploaded_at":"2024-10-04T21:00:06.875Z"'),
         Key: expect.stringMatching(`name.action/2024-09-04/repo-id`),
       }),
     );
@@ -115,11 +117,13 @@ describe('githubEventsToS3', () => {
     jest.spyOn(Date.prototype, 'getDate').mockReturnValue(4);
     jest.spyOn(Date.prototype, 'getMonth').mockReturnValue(8);
     jest.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2024);
+    jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-10-04T21:00:06.875Z');
 
     await githubEventsToS3(app, context, resource);
 
     expect(PutObjectCommand).toHaveBeenCalledWith(
       expect.objectContaining({
+        Body: expect.stringMatching('"uploaded_at":"2024-10-04T21:00:06.875Z"'),
         Key: expect.stringMatching(`name/2024-09-04/repo-id`),
       }),
     );


### PR DESCRIPTION
### Description
Added `uploaded_at` field to the raw event data json to allow later processing to easily know when the event was received. There is no consistent timestamp usable in the raw data itself.

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/76

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
