### PR TITLE
Remove resource config validation for github-events-to-s3 call

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -13,7 +13,7 @@ jobs:
         id: check
         uses: EndBug/version-check@v2
         with:
-          file-url: "https://raw.githubusercontent.com/opensearch-project/automation-app/refs/heads/${{ github.event.pull_request.base.ref }}/package.json"
+          file-url: 'https://raw.githubusercontent.com/opensearch-project/automation-app/refs/heads/${{ github.event.pull_request.base.ref }}/package.json'
           static-checking: localIsNew
 
       - name: Log when changed

--- a/configs/resources/opensearch-project-only-org.yml
+++ b/configs/resources/opensearch-project-only-org.yml
@@ -1,0 +1,3 @@
+---
+organizations:
+  - name: opensearch-project

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-automation-app",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.664.0",
         "@aws-sdk/client-opensearch": "^3.658.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "An Automation App that handles all your GitHub Repository Activities",
   "author": "Peter Zhu",
   "homepage": "https://github.com/opensearch-project/automation-app",

--- a/src/call/github-events-to-s3.ts
+++ b/src/call/github-events-to-s3.ts
@@ -12,30 +12,31 @@
 
 import { Probot } from 'probot';
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import { Resource } from '../service/resource/resource';
-import { validateResourceConfig } from '../utility/verification/verify-resource';
 
-export default async function githubEventsToS3(app: Probot, context: any, resource: Resource): Promise<void> {
-  if (!(await validateResourceConfig(app, context, resource))) return;
+export default async function githubEventsToS3(app: Probot, context: any): Promise<void> {
+  // Removed validateResourceConfig to let this function listen on all repos, and filter for only the repos that are public.
+  // This is done so when a new repo is made public, this app can automatically start processing its events.
+  // if (!(await validateResourceConfig(app, context, resource))) return;
+  if (context.payload.repository?.private === false) {
+    const repoName = context.payload.repository?.name;
+    const eventName = context.payload.action === undefined ? context.name : `${context.name}.${context.payload.action}`;
 
-  const repoName = context.payload.repository?.name;
-  const eventName = context.payload.action === undefined ? context.name : `${context.name}.${context.payload.action}`;
+    context.uploaded_at = new Date().toISOString();
 
-  context.uploaded_at = new Date().toISOString();
+    const now = new Date();
+    const [day, month, year] = [now.getDate(), now.getMonth() + 1, now.getFullYear()].map((num) => String(num).padStart(2, '0'));
 
-  const now = new Date();
-  const [day, month, year] = [now.getDate(), now.getMonth() + 1, now.getFullYear()].map((num) => String(num).padStart(2, '0'));
-
-  try {
-    const s3Client = new S3Client({ region: String(process.env.REGION) });
-    const putObjectCommand = new PutObjectCommand({
-      Bucket: String(process.env.OPENSEARCH_EVENTS_BUCKET),
-      Body: JSON.stringify(context),
-      Key: `${eventName}/${year}-${month}-${day}/${repoName}-${context.id}`,
-    });
-    await s3Client.send(putObjectCommand);
-    app.log.info('GitHub Event uploaded to S3 successfully.');
-  } catch (error) {
-    app.log.error(`Error uploading GitHub Event to S3 : ${error}`);
+    try {
+      const s3Client = new S3Client({ region: String(process.env.REGION) });
+      const putObjectCommand = new PutObjectCommand({
+        Bucket: String(process.env.OPENSEARCH_EVENTS_BUCKET),
+        Body: JSON.stringify(context),
+        Key: `${eventName}/${year}-${month}-${day}/${repoName}-${context.id}`,
+      });
+      await s3Client.send(putObjectCommand);
+      app.log.info('GitHub Event uploaded to S3 successfully.');
+    } catch (error) {
+      app.log.error(`Error uploading GitHub Event to S3 : ${error}`);
+    }
   }
 }

--- a/test/call/github-events-to-s3.test.ts
+++ b/test/call/github-events-to-s3.test.ts
@@ -16,7 +16,6 @@ jest.mock('@aws-sdk/client-s3');
 describe('githubEventsToS3', () => {
   let app: Probot;
   let context: any;
-  let resource: any;
   let mockS3Client: any;
 
   beforeEach(() => {
@@ -33,18 +32,9 @@ describe('githubEventsToS3', () => {
         repository: {
           name: 'repo',
           owner: { login: 'org' },
+          private: false,
         },
       },
-    };
-    resource = {
-      organizations: new Map([
-        [
-          'org',
-          {
-            repositories: new Map([['repo', 'repo object']]),
-          },
-        ],
-      ]),
     };
 
     mockS3Client = {
@@ -60,16 +50,35 @@ describe('githubEventsToS3', () => {
   it('should upload to S3 on event listened', async () => {
     mockS3Client.send.mockResolvedValue({});
 
-    await githubEventsToS3(app, context, resource);
+    await githubEventsToS3(app, context);
 
     expect(mockS3Client.send).toHaveBeenCalledWith(expect.any(PutObjectCommand));
     expect(app.log.info).toHaveBeenCalledWith('GitHub Event uploaded to S3 successfully.');
   });
 
+  it('should not upload to S3 on event listened on private repo', async () => {
+    context = {
+      name: 'name',
+      id: 'id',
+      payload: {
+        repository: {
+          name: 'repo',
+          owner: { login: 'org' },
+          private: true,
+        },
+      },
+    };
+    mockS3Client.send.mockResolvedValue({});
+
+    await githubEventsToS3(app, context);
+
+    expect(mockS3Client.send).not.toHaveBeenCalledWith(expect.any(PutObjectCommand));
+  });
+
   it('should log an error if S3 upload fails', async () => {
     mockS3Client.send.mockRejectedValue(new Error('S3 error'));
 
-    await githubEventsToS3(app, context, resource);
+    await githubEventsToS3(app, context);
 
     expect(app.log.error).toHaveBeenCalledWith('Error uploading GitHub Event to S3 : Error: S3 error');
   });
@@ -82,6 +91,7 @@ describe('githubEventsToS3', () => {
         repository: {
           name: 'repo',
           owner: { login: 'org' },
+          private: false,
         },
         action: 'action',
       },
@@ -92,7 +102,7 @@ describe('githubEventsToS3', () => {
     jest.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2024);
     jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-10-04T21:00:06.875Z');
 
-    await githubEventsToS3(app, context, resource);
+    await githubEventsToS3(app, context);
 
     expect(PutObjectCommand).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -110,6 +120,7 @@ describe('githubEventsToS3', () => {
         repository: {
           name: 'repo',
           owner: { login: 'org' },
+          private: false,
         },
       },
     };
@@ -119,7 +130,7 @@ describe('githubEventsToS3', () => {
     jest.spyOn(Date.prototype, 'getFullYear').mockReturnValue(2024);
     jest.spyOn(Date.prototype, 'toISOString').mockReturnValue('2024-10-04T21:00:06.875Z');
 
-    await githubEventsToS3(app, context, resource);
+    await githubEventsToS3(app, context);
 
     expect(PutObjectCommand).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/test/call/github-events-to-s3.test.ts
+++ b/test/call/github-events-to-s3.test.ts
@@ -73,6 +73,7 @@ describe('githubEventsToS3', () => {
     await githubEventsToS3(app, context);
 
     expect(mockS3Client.send).not.toHaveBeenCalledWith(expect.any(PutObjectCommand));
+    expect(app.log.error).toHaveBeenCalledWith('Event from repo skipped because it is a private repository.');
   });
 
   it('should log an error if S3 upload fails', async () => {

--- a/test/utility/probot/octokit.test.ts
+++ b/test/utility/probot/octokit.test.ts
@@ -13,7 +13,7 @@ import { Probot, ProbotOctokit, Logger } from 'probot';
 describe('octokitFunctions', () => {
   let app: Probot;
   let installationId: number;
-  let octokitMock: ProbotOctokit
+  let octokitMock: ProbotOctokit;
 
   beforeEach(() => {
     app = new Probot({ appId: 1, secret: 'test', privateKey: 'test' });


### PR DESCRIPTION
### Description
Remove resource config validation in github-events-to-s3 call to allow the app to listen on events from all repos, then filter only for public repos. This way, when a new repo is added, the app can start acting on the new repo's events immediately.

Additionally ran a `prettier --write .`

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/76

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
