### PR TITLE
Added check to events-to-s3 for label canary

### DIFF
--- a/configs/operations/github-events-to-s3.yml
+++ b/configs/operations/github-events-to-s3.yml
@@ -5,5 +5,12 @@ events:
   - all
 
 tasks:
+  - name: Github Label Canary Monitor
+    call: github-label-canary-monitor@default
+    args:
+      nameSpace: GitHubLabelCanary
+      metricName: AutomationApp_EventDataLake
+      value: '1'
+      unit: Count
   - name: Github Events To S3 Operation
     call: github-events-to-s3@default

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-automation-app",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.664.0",
         "@aws-sdk/client-opensearch": "^3.658.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "An Automation App that handles all your GitHub Repository Activities",
   "author": "Peter Zhu",
   "homepage": "https://github.com/opensearch-project/automation-app",

--- a/src/call/github-label-canary-monitor.ts
+++ b/src/call/github-label-canary-monitor.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+// Name         : githubLabelCanaryMonitor
+// Description  : Handle canary event by sending CloudWatch Metrics for monitoring purposes
+// Arguments    :
+//   - nameSpace: (string) The namespace of the CloudWatch Metric you want to send data to.
+//   - metricName: (string) The metric name of the CloudWatch Metric you want to send data to.
+//   - value: (string) The value of the CloudWatch Metric you want to send.
+//   - unit: (string) The unit of the CloudWatch Metric you want to send.
+
+import { Probot } from 'probot';
+import { CloudWatchClient, PutMetricDataCommand, StandardUnit } from '@aws-sdk/client-cloudwatch';
+import { Resource } from '../service/resource/resource';
+
+export interface LabelCanaryMonitorParams {
+  nameSpace: string;
+  metricName: string;
+  value: string;
+  unit: string;
+}
+
+export default async function githubLabelCanaryMonitor(
+  app: Probot,
+  context: any,
+  resource: Resource,
+  { nameSpace, metricName, value, unit }: LabelCanaryMonitorParams,
+): Promise<void> {
+  // Removed validateResourceConfig to let this function listen on all repos, and filter for only the repos that are public.
+  // This is done so when a new repo is made public, this app can automatically start processing its events.
+  //
+  // This is only for the s3 data lake specific case, everything else should still specify repos required to be listened in resource config.
+  //
+  // if (!(await validateResourceConfig(app, context, resource))) return;
+  //
+  const repoName = context.payload.repository?.name;
+  if (context.payload.repository?.private === false) {
+    // Handle canary event for monitoring purposes
+    if (repoName === 'opensearch-metrics' && context.name === 'label' && context.payload.label?.name === 's3-data-lake-app-canary-label') {
+      // Ignore if label was created
+      if (context.payload.action === 'deleted') {
+        try {
+          const cloudWatchClient = new CloudWatchClient({ region: String(process.env.REGION) });
+          const putMetricDataCommand = new PutMetricDataCommand({
+            Namespace: nameSpace,
+            MetricData: [
+              {
+                MetricName: metricName,
+                Value: Number(value),
+                Unit: unit as StandardUnit,
+              },
+            ],
+          });
+          await cloudWatchClient.send(putMetricDataCommand);
+          app.log.info('CloudWatch metric for monitoring published.');
+        } catch (error) {
+          app.log.error(`Error Publishing CloudWatch metric for monitoring : ${error}`);
+        }
+      }
+      return; // In the future, add `exit` right here to prevent subsequent tasks from running
+    }
+  }
+}

--- a/test/call/github-label-canary-monitor.test.ts
+++ b/test/call/github-label-canary-monitor.test.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+import { Logger, Probot } from 'probot';
+import githubLabelCanaryMonitor, { LabelCanaryMonitorParams } from '../../src/call/github-label-canary-monitor';
+import { CloudWatchClient, PutMetricDataCommand } from '@aws-sdk/client-cloudwatch';
+
+jest.mock('@aws-sdk/client-cloudwatch');
+
+describe('githubEventsToS3', () => {
+  let app: Probot;
+  let context: any;
+  let resource: any;
+  let mockCloudWatchClient: any;
+  let args: LabelCanaryMonitorParams;
+
+  beforeEach(() => {
+    args = {
+      nameSpace: 'testNameSpace',
+      metricName: 'testMetric',
+      value: '1',
+      unit: 'Count',
+    };
+
+    app = new Probot({ appId: 1, secret: 'test', privateKey: 'test' });
+    app.log = {
+      info: jest.fn(),
+      error: jest.fn(),
+    } as unknown as Logger;
+
+    context = {
+      name: 'name',
+      id: 'id',
+      payload: {
+        repository: {
+          name: 'repo',
+          owner: { login: 'org' },
+          private: false,
+        },
+      },
+    };
+
+    resource = {
+      organizations: new Map([
+        [
+          'org',
+          {
+            repositories: new Map([['repo', 'repo object']]),
+          },
+        ],
+      ]),
+    };
+
+    mockCloudWatchClient = {
+      send: jest.fn(),
+    };
+    (CloudWatchClient as jest.Mock).mockImplementation(() => mockCloudWatchClient);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should publish CloudWatch metric if event is label canary', async () => {
+    context = {
+      name: 'label',
+      id: 'id',
+      payload: {
+        action: 'deleted',
+        label: {
+          name: 's3-data-lake-app-canary-label',
+        },
+        repository: {
+          name: 'opensearch-metrics',
+          private: false,
+        },
+      },
+    };
+
+    mockCloudWatchClient.send.mockResolvedValue({});
+
+    await githubLabelCanaryMonitor(app, context, resource, args);
+
+    expect(mockCloudWatchClient.send).toHaveBeenCalledWith(expect.any(PutMetricDataCommand));
+    expect(app.log.info).toHaveBeenCalledWith('CloudWatch metric for monitoring published.');
+  });
+
+  it('should not publish CloudWatch metric if event is not label canary', async () => {
+    context = {
+      name: 'label',
+      id: 'id',
+      payload: {
+        label: {
+          name: 'normal-label',
+        },
+        repository: {
+          name: 'opensearch-metrics',
+          private: false,
+        },
+      },
+    };
+
+    mockCloudWatchClient.send.mockResolvedValue({});
+
+    await githubLabelCanaryMonitor(app, context, resource, args);
+
+    expect(mockCloudWatchClient.send).not.toHaveBeenCalledWith(expect.any(PutMetricDataCommand));
+    expect(app.log.info).not.toHaveBeenCalledWith('CloudWatch metric for monitoring published.');
+  });
+
+  it('should log an error if CloudWatch metric publishing fails', async () => {
+    context = {
+      name: 'label',
+      id: 'id',
+      payload: {
+        action: 'deleted',
+        label: {
+          name: 's3-data-lake-app-canary-label',
+        },
+        repository: {
+          name: 'opensearch-metrics',
+          private: false,
+        },
+      },
+    };
+
+    mockCloudWatchClient.send.mockRejectedValue(new Error('CloudWatch error'));
+
+    await githubLabelCanaryMonitor(app, context, resource, args);
+
+    expect(app.log.error).toHaveBeenCalledWith('Error Publishing CloudWatch metric for monitoring : Error: CloudWatch error');
+  });
+});


### PR DESCRIPTION
### Description
Added check to events-to-s3 for label canary

### Issues Resolved
Part of https://github.com/opensearch-project/opensearch-metrics/issues/105

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
