### PR TITLE
Add remote-vector-index-builder to automation-app config

### DIFF
--- a/configs/resources/opensearch-project-resource.yml
+++ b/configs/resources/opensearch-project-resource.yml
@@ -128,3 +128,4 @@ organizations:
       - name: technical-steering
       - name: opensearch-remote-metadata-sdk
       - name: opensearch-traffic-gateway
+      - name: remote-vector-index-builder

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-automation-app",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "dependencies": {
         "@aws-sdk/client-cloudwatch": "^3.664.0",
         "@aws-sdk/client-opensearch": "^3.658.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "An Automation App that handles all your GitHub Repository Activities",
   "author": "Peter Zhu",
   "homepage": "https://github.com/opensearch-project/automation-app",


### PR DESCRIPTION
### Description
Adds remote-vector-index-builder to automation-app config

### Issues Resolved
Part of [#5343 ](https://github.com/opensearch-project/opensearch-build/issues/5343)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
