### PR TITLE
Add default region as us-east-1 to bedrock client

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,14 @@ When you run the above command, the following takes place:
 
 #### List of Environment Variables (You can use them directly in the startup command, export them, or add them to the `.env` file):
 
-| Name                        | Type    | Default   | Description                                                                                                                                                        | Example                                   |
-| --------------------------- | ------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
-| RESOURCE_CONFIG             | String  | ''        | Path to resource config yaml file.                                                                                                                                 | 'configs/resources/sample-resource.yml'   |
-| OPERATION_CONFIG            | String  | ''        | Path to operation config yaml file.                                                                                                                                | 'configs/operations/sample-operation.yml' |
-| INSTALLATION_ID             | String  | ''        | Installation Id of your GitHub App, must install the App to repositories before retrieving the id.                                                                 | '1234567890'                              |
-| ADDITIONAL_RESOURCE_CONTEXT | Boolean | false     | Setting true will let each resource defined in RESOURCE_CONFIG to call GitHub Rest API and GraphQL for more detailed context (ex: node_id). Increase startup time. | true / false                              |
-| SERVICE_NAME                | String  | 'default' | Set Service Name                                                                                                                                                   | 'My Service'                              |
+| Name                        | Type    | Default     | Description                                                                                                                                                        | Example                                   |
+| --------------------------- | ------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| RESOURCE_CONFIG             | String  | ''          | Path to resource config yaml file.                                                                                                                                 | 'configs/resources/sample-resource.yml'   |
+| OPERATION_CONFIG            | String  | ''          | Path to operation config yaml file.                                                                                                                                | 'configs/operations/sample-operation.yml' |
+| INSTALLATION_ID             | String  | ''          | Installation Id of your GitHub App, must install the App to repositories before retrieving the id.                                                                 | '1234567890'                              |
+| ADDITIONAL_RESOURCE_CONTEXT | Boolean | false       | Setting true will let each resource defined in RESOURCE_CONFIG to call GitHub Rest API and GraphQL for more detailed context (ex: node_id). Increase startup time. | true / false                              |
+| SERVICE_NAME                | String  | 'default'   | Set Service Name                                                                                                                                                   | 'My Service'                              |
+| AWS_REGION_NAME             | String  | 'us-east-1' | Set AWS Region Name                                                                                                                                                | 'us-east-1'                               |
 
 #### Start the Service with Docker
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-automation-app",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.840.0",
         "@aws-sdk/client-cloudwatch": "^3.664.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-automation-app",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An Automation App that handles all your GitHub Repository Activities",
   "author": "Peter Zhu",
   "homepage": "https://github.com/opensearch-project/automation-app",

--- a/src/utility/llm/bedrock-client.ts
+++ b/src/utility/llm/bedrock-client.ts
@@ -9,7 +9,7 @@
 
 import { BedrockRuntimeClient, ConverseCommand, ConverseCommandInput } from '@aws-sdk/client-bedrock-runtime';
 
-export const bedrockClient = new BedrockRuntimeClient({ region: process.env.AWS_REGION_NAME });
+export const bedrockClient = new BedrockRuntimeClient({ region: process.env.AWS_REGION_NAME || 'us-east-1' });
 
 export async function bedrockConverse(
   promptText: string,


### PR DESCRIPTION
### Description
Add default region as us-east-1 to bedrock client

### Issues Resolved
https://github.com/opensearch-project/automation-app/issues/67
https://github.com/opensearch-project/automation-app/issues/55

```
INFO (probot): keyword 'lucene' found, keywordIgnoreCase = 'true', label = 'lucene', useLLM = 'true'
ERROR (probot): ERROR: Error: Region is missing
WARN (probot): Error in bedrock, fallback to simple text matching now ...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
